### PR TITLE
Make transcription panel optional with -transcription flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ Thumbs.db
 bin/
 dist/
 build/
-rhesis
+./rhesis
 
 # Temporary files
 *.tmp

--- a/cmd/rhesis/main.go
+++ b/cmd/rhesis/main.go
@@ -13,16 +13,17 @@ import (
 
 func main() {
 	var (
-		scriptPath = flag.String("script", "", "Path to the presentation script file")
-		outputPath = flag.String("output", "presentation.html", "Output HTML file path")
-		recordPath = flag.String("record", "", "Path to save video recording (optional)")
-		play       = flag.Bool("play", false, "Play the presentation after generating")
-		style      = flag.String("style", "modern", "Presentation style (modern, minimal, dark, elegant, or path to custom CSS file)")
+		scriptPath    = flag.String("script", "", "Path to the presentation script file")
+		outputPath    = flag.String("output", "presentation.html", "Output HTML file path")
+		recordPath    = flag.String("record", "", "Path to save video recording (optional)")
+		play          = flag.Bool("play", false, "Play the presentation after generating")
+		style         = flag.String("style", "modern", "Presentation style (modern, minimal, dark, elegant, or path to custom CSS file)")
+		transcription = flag.Bool("transcription", false, "Include transcription panel in presentation")
 	)
 	flag.Parse()
 
 	if *scriptPath == "" {
-		fmt.Println("Usage: rhesis -script <script-file> [-output <html-file>] [-style <style-name|css-file>] [-record <video-file>] [-play]")
+		fmt.Println("Usage: rhesis -script <script-file> [-output <html-file>] [-style <style-name|css-file>] [-record <video-file>] [-play] [-transcription]")
 		os.Exit(1)
 	}
 
@@ -32,7 +33,7 @@ func main() {
 	}
 
 	gen := generator.NewHTMLGenerator()
-	if err := gen.GeneratePresentation(parsedScript, *outputPath, *style); err != nil {
+	if err := gen.GeneratePresentation(parsedScript, *outputPath, *style, *transcription); err != nil {
 		log.Fatalf("Failed to generate presentation: %v", err)
 	}
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -218,6 +218,18 @@ const htmlTemplate = `<!DOCTYPE html>
             flex: 1;
             width: 100%;
         }
+        
+        /* Responsive adjustments when transcription is not included */
+        @media (max-width: 768px) {
+            .presentation-container {
+                flex-direction: column;
+            }
+            
+            .slide-area {
+                flex: 1;
+                padding: 20px;
+            }
+        }
         {{end}}
     </style>
 </head>

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -83,20 +83,22 @@ func NewHTMLGenerator() *HTMLGenerator {
 	}
 }
 
-func (h *HTMLGenerator) GeneratePresentation(s *script.Script, outputPath string, theme string) error {
+func (h *HTMLGenerator) GeneratePresentation(s *script.Script, outputPath string, theme string, includeTranscription bool) error {
 	styleCSS, err := h.styleManager.GetStyle(theme)
 	if err != nil {
 		return fmt.Errorf("failed to get style: %w", err)
 	}
 
 	data := struct {
-		Script *script.Script
-		Slides []SlideData
-		Style  template.CSS
+		Script               *script.Script
+		Slides               []SlideData
+		Style                template.CSS
+		IncludeTranscription bool
 	}{
-		Script: s,
-		Slides: h.processSlides(s.Slides),
-		Style:  template.CSS(styleCSS),
+		Script:               s,
+		Slides:               h.processSlides(s.Slides),
+		Style:                template.CSS(styleCSS),
+		IncludeTranscription: includeTranscription,
 	}
 
 	file, err := os.Create(outputPath)
@@ -210,6 +212,13 @@ const htmlTemplate = `<!DOCTYPE html>
     <title>{{.Script.Title}}</title>
     <style>
         {{.Style}}
+        {{if not .IncludeTranscription}}
+        /* Adjust layout when transcription is not included */
+        .slide-area {
+            flex: 1;
+            width: 100%;
+        }
+        {{end}}
     </style>
 </head>
 <body>
@@ -226,6 +235,7 @@ const htmlTemplate = `<!DOCTYPE html>
             {{end}}
         </div>
         
+        {{if .IncludeTranscription}}
         <div class="transcription-area">
             <div class="transcription-title">Transcription</div>
             <div class="transcription-content" id="transcriptionContent">
@@ -236,6 +246,7 @@ const htmlTemplate = `<!DOCTYPE html>
                 {{end}}
             </div>
         </div>
+        {{end}}
     </div>
     
     <div class="slide-counter">
@@ -275,23 +286,28 @@ const htmlTemplate = `<!DOCTYPE html>
         
         function showSlide(index) {
             slides.forEach(slide => slide.classList.remove('active'));
-            transcriptionSlides.forEach(trans => trans.style.display = 'none');
             
-            // Remove active class from transcription content
             const transcriptionContent = document.getElementById('transcriptionContent');
-            transcriptionContent.classList.remove('active');
+            if (transcriptionContent) {
+                transcriptionSlides.forEach(trans => trans.style.display = 'none');
+                transcriptionContent.classList.remove('active');
+            }
             
             if (index >= 0 && index < slides.length) {
                 slides[index].classList.add('active');
-                transcriptionSlides[index].style.display = 'block';
+                if (transcriptionContent && transcriptionSlides[index]) {
+                    transcriptionSlides[index].style.display = 'block';
+                }
                 currentSlideIndex = index;
                 window.currentSlideIndex = index;
                 currentSlideSpan.textContent = index + 1;
                 
                 // Fade in transcription content
-                setTimeout(() => {
-                    transcriptionContent.classList.add('active');
-                }, 100);
+                if (transcriptionContent) {
+                    setTimeout(() => {
+                        transcriptionContent.classList.add('active');
+                    }, 100);
+                }
             }
         }
         


### PR DESCRIPTION
## Summary
- Added a `-transcription` command line flag to make the transcription right panel optional
- By default, presentations are generated without the transcription panel
- When `-transcription` flag is used, the transcription panel is included

## Changes
- Added `-transcription` boolean flag to command line arguments
- Updated `GeneratePresentation` function to accept transcription parameter
- Made transcription panel HTML conditionally rendered in template
- Updated JavaScript to handle missing transcription elements gracefully
- Added CSS rule to expand slide area to full width when transcription is disabled

## Test plan
- [x] Build the application: `go build -o rhesis ./cmd/rhesis/`
- [x] Generate presentation without transcription: `./rhesis -script example.md -output test.html`
- [x] Verify transcription panel is not present in the output
- [x] Generate presentation with transcription: `./rhesis -script example.md -output test.html -transcription`
- [x] Verify transcription panel is present and functional in the output
- [x] Test slide navigation works correctly in both modes