### PR TITLE
Add subtitle generation from transcriptions

### DIFF
--- a/cmd/rhesis/main.go
+++ b/cmd/rhesis/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jmcarbo/rhesis/internal/generator"
 	"github.com/jmcarbo/rhesis/internal/player"
 	"github.com/jmcarbo/rhesis/internal/script"
+	"github.com/jmcarbo/rhesis/internal/subtitle"
 )
 
 func main() {
@@ -19,11 +20,12 @@ func main() {
 		play          = flag.Bool("play", false, "Play the presentation after generating")
 		style         = flag.String("style", "modern", "Presentation style (modern, minimal, dark, elegant, or path to custom CSS file)")
 		transcription = flag.Bool("transcription", false, "Include transcription panel in presentation")
+		subtitlePath  = flag.String("subtitle", "", "Generate subtitle file (optional, .srt or .vtt)")
 	)
 	flag.Parse()
 
 	if *scriptPath == "" {
-		fmt.Println("Usage: rhesis -script <script-file> [-output <html-file>] [-style <style-name|css-file>] [-record <video-file>] [-play] [-transcription]")
+		fmt.Println("Usage: rhesis -script <script-file> [-output <html-file>] [-style <style-name|css-file>] [-record <video-file>] [-play] [-transcription] [-subtitle <subtitle-file>]")
 		os.Exit(1)
 	}
 
@@ -38,6 +40,28 @@ func main() {
 	}
 
 	fmt.Printf("Presentation generated: %s\n", *outputPath)
+
+	// Generate subtitle file if requested
+	if *subtitlePath != "" {
+		// Extract transcriptions and durations from slides
+		var transcriptions []string
+		var durations []int
+		for _, slide := range parsedScript.Slides {
+			transcriptions = append(transcriptions, slide.Transcription)
+			durations = append(durations, slide.Duration)
+		}
+
+		// Generate subtitles
+		format := subtitle.DetectFormat(*subtitlePath)
+		gen := subtitle.NewGenerator(format)
+		subtitleContent := gen.Generate(transcriptions, durations, parsedScript.DefaultTime)
+
+		// Write subtitle file
+		if err := os.WriteFile(*subtitlePath, []byte(subtitleContent), 0644); err != nil {
+			log.Fatalf("Failed to write subtitle file: %v", err)
+		}
+		fmt.Printf("Subtitle file generated: %s\n", *subtitlePath)
+	}
 
 	if *play {
 		p := player.NewPresentationPlayer()

--- a/internal/subtitle/subtitle.go
+++ b/internal/subtitle/subtitle.go
@@ -1,0 +1,199 @@
+package subtitle
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SubtitleFormat represents the format of the subtitle file
+type SubtitleFormat string
+
+const (
+	FormatSRT    SubtitleFormat = "srt"
+	FormatWebVTT SubtitleFormat = "vtt"
+)
+
+// Subtitle represents a single subtitle entry
+type Subtitle struct {
+	Index     int
+	StartTime time.Duration
+	EndTime   time.Duration
+	Text      string
+}
+
+// Generator handles subtitle generation from slide transcriptions
+type Generator struct {
+	format SubtitleFormat
+}
+
+// NewGenerator creates a new subtitle generator
+func NewGenerator(format SubtitleFormat) *Generator {
+	return &Generator{
+		format: format,
+	}
+}
+
+// Generate creates subtitle content from slide transcriptions
+func (g *Generator) Generate(transcriptions []string, durations []int, defaultDuration int) string {
+	var subtitles []Subtitle
+	currentTime := time.Duration(0)
+
+	for i, transcription := range transcriptions {
+		if transcription == "" {
+			continue
+		}
+
+		// Get duration for this slide
+		duration := defaultDuration
+		if i < len(durations) && durations[i] > 0 {
+			duration = durations[i]
+		}
+		slideDuration := time.Duration(duration) * time.Second
+
+		// Split transcription into subtitle chunks (max 2 lines, ~50 chars per line)
+		chunks := g.splitIntoChunks(transcription, 100)
+
+		// Calculate time per chunk
+		chunkDuration := slideDuration / time.Duration(len(chunks))
+
+		for _, chunk := range chunks {
+			subtitle := Subtitle{
+				Index:     len(subtitles) + 1,
+				StartTime: currentTime,
+				EndTime:   currentTime + chunkDuration,
+				Text:      chunk,
+			}
+			subtitles = append(subtitles, subtitle)
+			currentTime = subtitle.EndTime
+		}
+	}
+
+	// Format subtitles based on the selected format
+	switch g.format {
+	case FormatSRT:
+		return g.formatSRT(subtitles)
+	case FormatWebVTT:
+		return g.formatWebVTT(subtitles)
+	default:
+		return g.formatSRT(subtitles)
+	}
+}
+
+// splitIntoChunks splits text into subtitle-friendly chunks
+func (g *Generator) splitIntoChunks(text string, maxCharsPerChunk int) []string {
+	// Remove markdown formatting
+	text = g.cleanMarkdown(text)
+
+	words := strings.Fields(text)
+	var chunks []string
+	var currentChunk []string
+	currentLength := 0
+
+	for _, word := range words {
+		wordLength := len(word)
+
+		// If adding this word would exceed the limit, start a new chunk
+		if currentLength > 0 && currentLength+wordLength+1 > maxCharsPerChunk {
+			chunks = append(chunks, strings.Join(currentChunk, " "))
+			currentChunk = []string{}
+			currentLength = 0
+		}
+
+		currentChunk = append(currentChunk, word)
+		currentLength += wordLength
+		if currentLength > 0 {
+			currentLength++ // Space between words
+		}
+	}
+
+	// Add the last chunk
+	if len(currentChunk) > 0 {
+		chunks = append(chunks, strings.Join(currentChunk, " "))
+	}
+
+	return chunks
+}
+
+// cleanMarkdown removes common markdown formatting
+func (g *Generator) cleanMarkdown(text string) string {
+	// Remove code blocks
+	text = strings.ReplaceAll(text, "```", "")
+
+	// Remove bold/italic markers
+	text = strings.ReplaceAll(text, "**", "")
+	text = strings.ReplaceAll(text, "__", "")
+	text = strings.ReplaceAll(text, "*", "")
+	text = strings.ReplaceAll(text, "_", "")
+
+	// Remove headers
+	lines := strings.Split(text, "\n")
+	var cleanedLines []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "#") && line != "" {
+			cleanedLines = append(cleanedLines, line)
+		}
+	}
+
+	return strings.Join(cleanedLines, " ")
+}
+
+// formatSRT formats subtitles in SRT format
+func (g *Generator) formatSRT(subtitles []Subtitle) string {
+	var result strings.Builder
+
+	for _, sub := range subtitles {
+		result.WriteString(fmt.Sprintf("%d\n", sub.Index))
+		result.WriteString(fmt.Sprintf("%s --> %s\n",
+			g.formatTimeSRT(sub.StartTime),
+			g.formatTimeSRT(sub.EndTime)))
+		result.WriteString(fmt.Sprintf("%s\n\n", sub.Text))
+	}
+
+	return result.String()
+}
+
+// formatWebVTT formats subtitles in WebVTT format
+func (g *Generator) formatWebVTT(subtitles []Subtitle) string {
+	var result strings.Builder
+
+	result.WriteString("WEBVTT\n\n")
+
+	for _, sub := range subtitles {
+		result.WriteString(fmt.Sprintf("%s --> %s\n",
+			g.formatTimeWebVTT(sub.StartTime),
+			g.formatTimeWebVTT(sub.EndTime)))
+		result.WriteString(fmt.Sprintf("%s\n\n", sub.Text))
+	}
+
+	return result.String()
+}
+
+// formatTimeSRT formats time for SRT format (HH:MM:SS,mmm)
+func (g *Generator) formatTimeSRT(d time.Duration) string {
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+	milliseconds := int(d.Milliseconds()) % 1000
+
+	return fmt.Sprintf("%02d:%02d:%02d,%03d", hours, minutes, seconds, milliseconds)
+}
+
+// formatTimeWebVTT formats time for WebVTT format (HH:MM:SS.mmm)
+func (g *Generator) formatTimeWebVTT(d time.Duration) string {
+	hours := int(d.Hours())
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+	milliseconds := int(d.Milliseconds()) % 1000
+
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds)
+}
+
+// DetectFormat detects subtitle format from file extension
+func DetectFormat(filename string) SubtitleFormat {
+	if strings.HasSuffix(strings.ToLower(filename), ".vtt") {
+		return FormatWebVTT
+	}
+	return FormatSRT
+}


### PR DESCRIPTION
## Summary
- Add `-subtitle` command line flag to generate subtitle files (.srt or .vtt)
- Use existing slide transcriptions as the base for subtitle content
- Support proper timing based on slide durations

## Test plan
- [x] Test SRT subtitle generation with `rhesis -script presentation.md -subtitle output.srt`
- [x] Test WebVTT subtitle generation with `rhesis -script presentation.md -subtitle output.vtt`
- [x] Verify subtitle timing matches slide durations
- [x] Verify markdown formatting is properly cleaned from subtitles
- [x] Test with slides that have no transcriptions (should be skipped)