### PR TITLE
Add --fuse option to merge video and audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,17 @@ export ELEVENLABS_API_KEY=your_api_key
 
 # Generate and record in background mode (no visible browser)
 ./bin/rhesis -script presentation.md -output presentation.html -sound -play -record video.mp4 -background -elevenlabs-key YOUR_API_KEY
+
+# Fuse existing video and audio files (without presentation generation)
+./bin/rhesis -fuse -video input.webm -audio audio.mp3 -output output.mp4
+
+# Fuse video with multiple audio files from a directory
+./bin/rhesis -fuse -video input.webm -audio audio_dir/ -output output.mp4 -durations 10,15,20,10
 ```
 
 ### Command Line Options
 
+#### Presentation Mode
 - `-script`: Path to the presentation script file (required)
 - `-output`: Output HTML file path (default: "presentation.html")
 - `-play`: Play the presentation after generating (optional)
@@ -95,6 +102,13 @@ export ELEVENLABS_API_KEY=your_api_key
 - `-skip-audio-creation`: Skip audio generation if audio files already exist (optional, use with -sound)
 - `-elevenlabs-key`: ElevenLabs API key (optional, can also use ELEVENLABS_API_KEY env var)
 - `-voice`: ElevenLabs voice ID (optional, defaults to Rachel voice)
+
+#### Fuse Mode
+- `-fuse`: Enable fuse mode to merge existing video and audio files (optional)
+- `-video`: Input video file path (required in fuse mode)
+- `-audio`: Input audio file path or directory containing audio files (required in fuse mode)
+- `-output`: Output video file path (required in fuse mode)
+- `-durations`: Comma-separated slide durations in seconds (required when `-audio` is a directory)
 
 ## Script Format
 
@@ -264,6 +278,40 @@ Example:
 # Record a presentation as MP4
 ./bin/rhesis -script demo.md -play -record output/demo.mp4
 ```
+
+## Fuse Mode
+
+The fuse mode allows you to merge existing video and audio files without generating a presentation. This is useful when you have:
+- A video recording and want to add audio narration
+- Multiple audio clips that need to be synchronized with video segments
+- Pre-recorded content that needs audio/video synchronization
+
+### Usage Examples
+
+#### Single Audio File
+Merge a single audio file with a video:
+```bash
+./bin/rhesis -fuse -video recording.webm -audio narration.mp3 -output final.mp4
+```
+
+#### Multiple Audio Files
+Merge multiple audio files from a directory with specified timings:
+```bash
+./bin/rhesis -fuse -video recording.webm -audio audio_clips/ -output final.mp4 -durations 10,15,20,10
+```
+
+The `-durations` parameter specifies how long each audio clip should play for (in seconds). Audio files in the directory are processed in alphabetical order.
+
+### Supported Formats
+- **Video**: WebM, MP4
+- **Audio**: MP3, WAV, M4A
+- **Output**: WebM, MP4 (format determined by file extension)
+
+The tool will automatically:
+- Synchronize audio with video
+- Adjust video framerate if audio is significantly longer than video
+- Handle codec conversions between WebM and MP4 formats
+- Add appropriate padding or trimming to match durations
 
 ## Development
 

--- a/internal/audio/merger.go
+++ b/internal/audio/merger.go
@@ -23,6 +23,25 @@ func NewAudioVideoMerger() *AudioVideoMerger {
 	}
 }
 
+// GetVideoDuration gets the duration of a video file
+func GetVideoDuration(videoPath string) (time.Duration, error) {
+	cmd := exec.Command("ffmpeg", "-i", videoPath)
+	output, _ := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	// Extract duration using regex
+	durationRegex := regexp.MustCompile(`Duration: (\d{2}):(\d{2}):(\d{2}\.\d+)`)
+	if matches := durationRegex.FindStringSubmatch(outputStr); len(matches) > 3 {
+		hours, _ := strconv.ParseFloat(matches[1], 64)
+		minutes, _ := strconv.ParseFloat(matches[2], 64)
+		seconds, _ := strconv.ParseFloat(matches[3], 64)
+		totalSeconds := hours*3600 + minutes*60 + seconds
+		return time.Duration(totalSeconds * float64(time.Second)), nil
+	}
+
+	return 0, fmt.Errorf("could not extract duration from video file")
+}
+
 // MergeAudioWithVideo merges audio files with a video recording based on slide timings
 func (m *AudioVideoMerger) MergeAudioWithVideo(videoPath string, audioFiles []string, slideDurations []int, outputPath string) error {
 	// Check if ffmpeg is available


### PR DESCRIPTION
## Summary
- Added a new `--fuse` option that enables merging existing video and audio files without generating a presentation
- Supports both single audio file and multiple audio files from a directory
- Automatically handles codec conversions and duration synchronization

## Changes
- Added new command-line flags: `-fuse`, `-video`, `-audio`, and `-durations`
- Implemented `runFuseMode` function to handle the fuse operation
- Added `GetVideoDuration` function to extract video duration using ffmpeg
- Updated README.md with documentation for the new fuse mode

## Usage Examples

### Single Audio File
```bash
./bin/rhesis -fuse -video recording.webm -audio narration.mp3 -output final.mp4
```

### Multiple Audio Files
```bash
./bin/rhesis -fuse -video recording.webm -audio audio_clips/ -output final.mp4 -durations 10,15,20,10
```

## Test Plan
- [x] Tested merging single audio file with video
- [x] Tested merging multiple audio files from directory with specified durations
- [x] Verified codec conversion between WebM and MP4
- [x] Confirmed duration synchronization works correctly