### PR TITLE
Always adjust slide duration to audio duration with 0.5s buffer

### DIFF
--- a/cmd/rhesis/main.go
+++ b/cmd/rhesis/main.go
@@ -98,16 +98,15 @@ func main() {
 						// Audio file exists, skip generation
 						fmt.Printf("Using existing audio file for slide %d: %s\n", i+1, audioPath)
 
-						// Get audio duration to adjust slide timing if needed
+						// Get audio duration to adjust slide timing
 						audioDuration, err := audio.GetAudioDuration(audioPath)
 						if err == nil {
-							audioDurationSeconds := int(audioDuration.Seconds())
+							audioDurationSeconds := audioDuration.Seconds()
 							originalDuration := slide.Duration
-							if audioDurationSeconds > slide.Duration {
-								parsedScript.Slides[i].Duration = audioDurationSeconds + 1 // Add 1 second buffer
-								fmt.Printf("Adjusted slide %d duration from %ds to %ds to accommodate audio\n",
-									i+1, originalDuration, parsedScript.Slides[i].Duration)
-							}
+							// Always adjust slide duration to audio duration + 0.5 seconds
+							parsedScript.Slides[i].Duration = int(audioDurationSeconds + 0.5)
+							fmt.Printf("Adjusted slide %d duration from %ds to %.1fs to match audio + 0.5s buffer\n",
+								i+1, originalDuration, audioDurationSeconds + 0.5)
 						} else {
 							fmt.Printf("Warning: Could not get duration for audio file %s: %v\n", audioPath, err)
 						}
@@ -132,14 +131,12 @@ func main() {
 					audioDuration = actualDuration
 				}
 
-				// Adjust slide duration if audio is longer
-				audioDurationSeconds := int(audioDuration.Seconds())
+				// Always adjust slide duration to audio duration + 0.5 seconds
+				audioDurationSeconds := audioDuration.Seconds()
 				originalDuration := slide.Duration
-				if audioDurationSeconds > slide.Duration {
-					parsedScript.Slides[i].Duration = audioDurationSeconds + 1 // Add 1 second buffer
-					fmt.Printf("Adjusted slide %d duration from %ds to %ds to accommodate audio\n",
-						i+1, originalDuration, parsedScript.Slides[i].Duration)
-				}
+				parsedScript.Slides[i].Duration = int(audioDurationSeconds + 0.5)
+				fmt.Printf("Adjusted slide %d duration from %ds to %.1fs to match audio + 0.5s buffer\n",
+					i+1, originalDuration, audioDurationSeconds + 0.5)
 
 				audioFiles = append(audioFiles, audioPath)
 				fmt.Printf("Generated audio for slide %d (duration: %v)\n", i+1, audioDuration)


### PR DESCRIPTION
## Summary
- Changed audio-based slide duration adjustment to always apply when audio is present
- Reduced buffer time from 1 second to 0.5 seconds for smoother transitions
- Ensures consistent timing behavior regardless of original slide duration

## Changes
When audio is used for slides, the slide duration is now always adjusted to match the audio duration plus a 0.5 second buffer. This provides a small silence between slides for better presentation flow.

Previously:
- Duration was only adjusted when audio was longer than the original slide duration
- Used a 1 second buffer

Now:
- Duration is always adjusted to audio duration + 0.5s when audio is present
- Provides consistent behavior and smoother transitions

## Test plan
- [ ] Build the project with `go build ./cmd/rhesis`
- [ ] Test with a presentation that includes audio
- [ ] Verify that slide durations match audio duration + 0.5s
- [ ] Confirm smooth transitions between slides with audio